### PR TITLE
Fix failed to send files by file_id

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -344,7 +344,7 @@ class Request
                     $has_resource = true;
 
                     continue;
-                } elseif (str_contains('/', $item) && !filter_var($item, FILTER_VALIDATE_URL)) {
+                } elseif (str_contains($item, '/') && !filter_var($item, FILTER_VALIDATE_URL)) {
                     throw new TelegramException(
                         'Invalid file path or URL: ' . $item . ' for ' . self::$current_action . ' action'
                     );

--- a/src/Request.php
+++ b/src/Request.php
@@ -339,22 +339,16 @@ class Request
 
         foreach ($data as $key => &$item) {
             if (array_key_exists(self::$current_action, self::$input_file_fields) && in_array($key, self::$input_file_fields[self::$current_action], true)) {
-
                 if (is_string($item) && file_exists($item)) {
+                    $multipart[$key] = $item;
                     $has_resource = true;
 
-                } elseif (filter_var($item, FILTER_VALIDATE_URL)) {
-                    $has_resource = false;
                     continue;
-
-                } else {
+                } elseif (str_contains('/', $item) && !filter_var($item, FILTER_VALIDATE_URL)) {
                     throw new TelegramException(
                         'Invalid file path or URL: ' . $item . ' for ' . self::$current_action . ' action'
                     );
                 }
-
-                $multipart[$key] = $item;
-                continue;
             }
 
             if ($item instanceof Entity) {


### PR DESCRIPTION
When trying to send file by file_id, this exception is thrown: 
> Invalid file path or URL: <_file_id_> for <_api_method_> action.

**Example**
```php
// https://core.telegram.org/bots/api#sendphoto
Request::create('sendPhoto', [
    'chat_id' => '259760855',
    'photo'   => 'AgACAgQAAxkDAAIBO2XA0gLau-CWfOy_HQFZSoBuy2JrAAIqszEbH2EFUqWHEB4k6Y_RAQADAgADdwADNAQ'
]);
```
That is, now files can be sent either by url or posted using multipart/form-data. According to the [documentation](https://core.telegram.org/bots/api#inputfile), this is incorrect behavior
